### PR TITLE
fix: correct homepage redirect to valid docs/ai/ path

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,5 +2,5 @@ import React from 'react';
 import { Redirect } from '@docusaurus/router';
 
 export default function Home(): JSX.Element {
-    return <Redirect to="/yiwen-blog-website/docs/ai/intro" />;
+    return <Redirect to="/yiwen-blog-website/docs/ai/" />;
 }


### PR DESCRIPTION
## Summary
- Homepage was redirecting to `/yiwen-blog-website/docs/ai/intro` which doesn't exist, causing a broken link
- Changed redirect target to `/yiwen-blog-website/docs/ai/` which resolves to the generated index page defined in `docs/ai/_category_.json`

## Test plan
- [x] Visit the homepage and verify it redirects to the AI docs index page
- [x] Verify the AI docs index page loads correctly

https://claude.ai/code/session_01PfrAVuZ6AxuTKCLWbGYQzC